### PR TITLE
Remove duplicate tag

### DIFF
--- a/doc/ctrlp-menu.txt
+++ b/doc/ctrlp-menu.txt
@@ -1,5 +1,5 @@
 *ctrlp-menu.txt*	menu support for ctrlp
-wsdjeg                                               *ctrlp-menu* *ctrlp-menu*
+wsdjeg                                                            *ctrlp-menu*
 
 ==============================================================================
 CONTENTS                                                 *ctrlp-menu-contents*


### PR DESCRIPTION
Noticed dein complaining about duplicate tag ctrlp-menu when indexing doc, and it really is there twice, so I just removed one.